### PR TITLE
Add oci-distribution demo workflows for 5 registries

### DIFF
--- a/.github/oci-distribution/package.json
+++ b/.github/oci-distribution/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "oci-distribution-ci",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Shared CI script that exercises the oci-distribution npm package against OCI registries.",
+  "engines": {
+    "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+  }
+}

--- a/.github/oci-distribution/test.mjs
+++ b/.github/oci-distribution/test.mjs
@@ -1,0 +1,179 @@
+// Exercises the `oci-distribution` npm package end-to-end against a single OCI
+// registry. It pushes a dummy image, attaches a related artifact to that image
+// (the same shape as attaching an attestation to an image), then reads the
+// artifact back by walking the image's referrers and pulling the artifact's
+// content blob.
+//
+// Authentication is taken from the Docker config that the workflow's registry
+// login step already populated (`~/.docker/config.json`), so this one script
+// works unchanged across GHCR, Docker Hub, Azure ACR, AWS ECR, and Google
+// Artifact Registry.
+//
+// Configuration (environment variables):
+//   OCI_REGISTRY       required, e.g. "ghcr.io"
+//   OCI_REPOSITORY     required, e.g. "bdehamer/attest-demo"
+//   OCI_TAG            optional, tag for the dummy image (default "oci-dist")
+//   OCI_ARTIFACT_TYPE  optional, artifactType of the attached artifact
+
+import assert from 'node:assert/strict'
+import {
+  Registry,
+  dockerConfigCredential,
+  MEDIA_TYPE_OCI_IMAGE_MANIFEST,
+  MEDIA_TYPE_OCI_IMAGE_CONFIG,
+  MEDIA_TYPE_OCI_LAYER,
+} from 'oci-distribution'
+
+const REGISTRY = requireEnv('OCI_REGISTRY')
+const REPOSITORY = requireEnv('OCI_REPOSITORY')
+const TAG = process.env.OCI_TAG || 'oci-dist'
+const ARTIFACT_TYPE =
+  process.env.OCI_ARTIFACT_TYPE ||
+  'application/vnd.oci-distribution.demo.artifact.v1+json'
+const ARTIFACT_LAYER_MEDIA_TYPE =
+  'application/vnd.oci-distribution.demo.content.v1+json'
+
+const enc = (s) => new TextEncoder().encode(s)
+
+function requireEnv(name) {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`missing required environment variable: ${name}`)
+  }
+  return value
+}
+
+function short(descriptor) {
+  return `${descriptor.digest} (${descriptor.size} bytes, ${descriptor.mediaType})`
+}
+
+// Build and push a minimal-but-valid OCI image (config + one layer) under TAG.
+async function pushDummyImage(repo) {
+  console.log(`\n▶ Pushing dummy image to ${REGISTRY}/${REPOSITORY}:${TAG}`)
+
+  // 1. A single layer. Content is arbitrary; the registry does not inspect it.
+  const layerBytes = enc(
+    `oci-distribution demo layer @ ${new Date().toISOString()}\n`,
+  )
+  const layer = await repo.pushBlob({ mediaType: MEDIA_TYPE_OCI_LAYER }, layerBytes)
+  console.log(`  • layer   ${short(layer)}`)
+
+  // 2. A minimal OCI image config that references the layer as a diff id.
+  const now = new Date().toISOString()
+  const configBytes = enc(
+    JSON.stringify({
+      created: now,
+      architecture: 'amd64',
+      os: 'linux',
+      config: {},
+      rootfs: { type: 'layers', diff_ids: [layer.digest] },
+      history: [{ created: now, created_by: 'oci-distribution demo' }],
+    }),
+  )
+  const config = await repo.pushBlob(
+    { mediaType: MEDIA_TYPE_OCI_IMAGE_CONFIG },
+    configBytes,
+  )
+  console.log(`  • config  ${short(config)}`)
+
+  // 3. The image manifest tying config + layer together, pushed under TAG.
+  const manifestBytes = enc(
+    JSON.stringify({
+      schemaVersion: 2,
+      mediaType: MEDIA_TYPE_OCI_IMAGE_MANIFEST,
+      config,
+      layers: [layer],
+    }),
+  )
+  const image = await repo.pushManifest(TAG, manifestBytes, {
+    mediaType: MEDIA_TYPE_OCI_IMAGE_MANIFEST,
+  })
+  console.log(`  • image   ${short(image)}`)
+  return image
+}
+
+// Attach an artifact manifest that references a content blob to `subject`.
+async function attachArtifact(repo, subject) {
+  console.log(`\n▶ Attaching ${ARTIFACT_TYPE} to the image`)
+
+  const payload = enc(
+    JSON.stringify({
+      _type: 'https://oci-distribution.example/demo/v1',
+      subject: { name: `${REGISTRY}/${REPOSITORY}`, digest: subject.digest },
+      note: 'artifact attached via the oci-distribution client',
+      timestamp: new Date().toISOString(),
+    }),
+  )
+  const content = await repo.pushBlob(
+    { mediaType: ARTIFACT_LAYER_MEDIA_TYPE },
+    payload,
+  )
+  console.log(`  • content ${short(content)}`)
+
+  const artifact = await repo.attachArtifact(subject, ARTIFACT_TYPE, [content], {
+    annotations: {
+      'org.opencontainers.image.created': new Date().toISOString(),
+      'dev.oci-distribution.demo': 'true',
+    },
+  })
+  console.log(`  • artifact ${short(artifact)}`)
+  return { artifact, payload }
+}
+
+// Walk the image's referrers, fetch the artifact manifest, and pull its blob.
+async function readBackArtifact(repo, subject, artifact, expectedPayload) {
+  console.log('\n▶ Reading the artifact back via the referrers API')
+
+  // 1. Discover referrers of the image, filtered to our artifact type.
+  const index = await repo.referrers.list(subject.digest, {
+    artifactType: ARTIFACT_TYPE,
+  })
+  console.log(`  • ${index.manifests.length} referrer(s) of type ${ARTIFACT_TYPE}`)
+  const referrer = index.manifests.find((m) => m.digest === artifact.digest)
+  assert.ok(referrer, 'attached artifact not found among the image referrers')
+  assert.equal(referrer.artifactType, ARTIFACT_TYPE)
+
+  // 2. Fetch the artifact manifest and confirm it points back at the image.
+  const { manifest } = await repo.getManifest(artifact.digest)
+  assert.equal(manifest.subject?.digest, subject.digest, 'artifact subject mismatch')
+  assert.equal(manifest.artifactType, ARTIFACT_TYPE)
+  const content = manifest.layers?.[0]
+  assert.ok(content, 'artifact manifest has no layers')
+
+  // 3. Pull the artifact's content blob (digest-verified by the client).
+  const pulled = await repo.blobs.get(content.digest)
+  assert.deepEqual(
+    pulled,
+    expectedPayload,
+    'pulled artifact content does not match what was pushed',
+  )
+  console.log(`  • pulled ${pulled.byteLength} bytes and verified content matches`)
+}
+
+async function main() {
+  console.log(
+    `oci-distribution demo → registry=${REGISTRY} repository=${REPOSITORY} tag=${TAG}`,
+  )
+
+  const registry = new Registry(REGISTRY, {
+    credentials: dockerConfigCredential(),
+  })
+  const repo = registry.repository(REPOSITORY)
+
+  const image = await pushDummyImage(repo)
+
+  // Confirm the image is retrievable by tag (read path for the image itself).
+  const resolved = await repo.resolve(TAG)
+  assert.equal(resolved.digest, image.digest, 'tag did not resolve to the pushed image')
+  console.log(`\n▶ Tag ${TAG} resolves to ${resolved.digest}`)
+
+  const { artifact, payload } = await attachArtifact(repo, image)
+  await readBackArtifact(repo, image, artifact, payload)
+
+  console.log('\n✅ Success: pushed an image, attached an artifact, and pulled it back.')
+}
+
+main().catch((err) => {
+  console.error(`\n❌ Failed: ${err?.stack || err}`)
+  process.exit(1)
+})

--- a/.github/workflows/oci-dist-amazon.yml
+++ b/.github/workflows/oci-dist-amazon.yml
@@ -1,0 +1,44 @@
+name: OCI Distribution Client (AWS ECR)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  oci-dist-ecr:
+    name: Push & Attach (ECR)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      REGISTRY: 123509514931.dkr.ecr.us-east-1.amazonaws.com
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: arn:aws:iam::123509514931:role/GitHubAction-AssumeRole
+          managed-session-policies: arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install oci-distribution
+        working-directory: .github/oci-distribution
+        run: npm install oci-distribution@latest
+
+      - name: Exercise oci-distribution
+        working-directory: .github/oci-distribution
+        env:
+          OCI_REGISTRY: ${{ env.REGISTRY }}
+          OCI_REPOSITORY: ${{ env.IMAGE_NAME }}
+        run: node test.mjs

--- a/.github/workflows/oci-dist-azure.yml
+++ b/.github/workflows/oci-dist-azure.yml
@@ -1,0 +1,44 @@
+name: OCI Distribution Client (Azure Container Registry)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  oci-dist-acr:
+    name: Push & Attach (ACR)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      REGISTRY: dehamer.azurecr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Azure
+        uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a # v2.1.1
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Set up docker credentials
+        run: az acr login --name ${{ env.REGISTRY }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install oci-distribution
+        working-directory: .github/oci-distribution
+        run: npm install oci-distribution@latest
+
+      - name: Exercise oci-distribution
+        working-directory: .github/oci-distribution
+        env:
+          OCI_REGISTRY: ${{ env.REGISTRY }}
+          OCI_REPOSITORY: ${{ env.IMAGE_NAME }}
+        run: node test.mjs

--- a/.github/workflows/oci-dist-docker-hub.yml
+++ b/.github/workflows/oci-dist-docker-hub.yml
@@ -1,0 +1,39 @@
+name: OCI Distribution Client (Docker Hub)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  oci-dist-dockerhub:
+    name: Push & Attach (Docker Hub)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      REGISTRY: docker.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install oci-distribution
+        working-directory: .github/oci-distribution
+        run: npm install oci-distribution@latest
+
+      - name: Exercise oci-distribution
+        working-directory: .github/oci-distribution
+        env:
+          OCI_REGISTRY: ${{ env.REGISTRY }}
+          OCI_REPOSITORY: ${{ env.IMAGE_NAME }}
+        run: node test.mjs

--- a/.github/workflows/oci-dist-github.yml
+++ b/.github/workflows/oci-dist-github.yml
@@ -1,0 +1,41 @@
+name: OCI Distribution Client (GH Container Registry)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  oci-dist-ghcr:
+    name: Push & Attach (GHCR)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install oci-distribution
+        working-directory: .github/oci-distribution
+        run: npm install oci-distribution@latest
+
+      - name: Exercise oci-distribution
+        working-directory: .github/oci-distribution
+        env:
+          OCI_REGISTRY: ${{ env.REGISTRY }}
+          OCI_REPOSITORY: ${{ env.IMAGE_NAME }}
+        run: node test.mjs

--- a/.github/workflows/oci-dist-google.yml
+++ b/.github/workflows/oci-dist-google.yml
@@ -1,0 +1,71 @@
+name: OCI Distribution Client (Google Artifact Registry)
+
+on:
+  workflow_dispatch:
+    inputs:
+      service-principal:
+        description: 'Use service principal to auth'
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  oci-dist-gar:
+    name: Push & Attach (GAR)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      REGISTRY: us-west1-docker.pkg.dev
+      IMAGE_NAME: dehamer24/${{ github.repository }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - uses: 'google-github-actions/auth@v2'
+        if: inputs.service-principal
+        id: auth1
+        with:
+          workload_identity_provider: ${{ vars.GCLOUD_WIF_PROVIDER }}
+          service_account: ${{ vars.GCLOUD_SERVICE_ACCOUNT }}
+          token_format: access_token
+
+      - name: Auth w/ registry
+        if: inputs.service-principal
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth1.outputs.access_token }}
+
+      - uses: 'google-github-actions/auth@v2'
+        if: ${{ !inputs.service-principal }}
+        id: auth2
+        with:
+          workload_identity_provider: ${{ vars.GCLOUD_WIF_PROVIDER2 }}
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+
+      - name: Auth w/ registry
+        if: ${{ !inputs.service-principal }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth2.outputs.auth_token }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install oci-distribution
+        working-directory: .github/oci-distribution
+        run: npm install oci-distribution@latest
+
+      - name: Exercise oci-distribution
+        working-directory: .github/oci-distribution
+        env:
+          OCI_REGISTRY: ${{ env.REGISTRY }}
+          OCI_REPOSITORY: ${{ env.IMAGE_NAME }}
+        run: node test.mjs


### PR DESCRIPTION
## Summary

Adds a parallel set of `oci-dist-*` workflows — for **GHCR, Docker Hub, Azure ACR, AWS ECR, and Google Artifact Registry** — that reuse the registry authentication already established in the existing `oci-*` workflows and run a shared Node script exercising the [`oci-distribution`](https://www.npmjs.com/package/oci-distribution) npm package.

Each workflow:
1. Authenticates to its registry using the **exact same steps** as the corresponding `oci-*` workflow (only QEMU/buildx/`actions/attest` steps are dropped — there's no docker build here).
2. Sets up Node 24 and installs `oci-distribution@latest`.
3. Runs `.github/oci-distribution/test.mjs`.

## What the script does

Registry-agnostic and env-driven (`OCI_REGISTRY` / `OCI_REPOSITORY` / `OCI_TAG`):

- **Push** a dummy image (layer + config + image manifest), tagged `oci-dist`.
- Confirm the image **resolves by tag** (image read path).
- **Attach** a related artifact to the image via the OCI 1.1 referrers/subject model — the same shape attestations use — with `repo.attachArtifact(...)`.
- **Read path:** list the image's referrers, fetch the artifact manifest, and pull its content blob back, verifying the bytes match what was pushed.

Authentication is read from the Docker config the login steps already populate (`~/.docker/config.json`) via `dockerConfigCredential()`, so one script works unchanged across all five registries (inline auths, ACR `identitytoken`, and credential helpers all handled).

## New files

| File | Purpose |
|---|---|
| `.github/oci-distribution/test.mjs` | Shared, env-driven exercise script |
| `.github/oci-distribution/package.json` | Minimal ESM marker (`node_modules` is gitignored) |
| `.github/workflows/oci-dist-github.yml` | GHCR (`GITHUB_TOKEN`, `packages: write`) |
| `.github/workflows/oci-dist-docker-hub.yml` | Docker Hub (`DOCKER_HUB_TOKEN`) |
| `.github/workflows/oci-dist-azure.yml` | Azure ACR (`azure/login` OIDC + `az acr login`) |
| `.github/workflows/oci-dist-amazon.yml` | AWS ECR (`configure-aws-credentials` + `amazon-ecr-login`) |
| `.github/workflows/oci-dist-google.yml` | Google Artifact Registry (`google-github-actions/auth` WIF) |

## Validation

- `node --check` on the script and YAML-parse of all 5 workflows pass.
- Ran the script **end-to-end against a local `registry:3`**: image pushed, tag resolved, artifact attached via the referrers API, referrer discovered, blob pulled and content verified (exit 0). Failure paths (missing env, unreachable registry) exit non-zero.

## Notes

- Installs `oci-distribution@latest` (0.1.0 today — already exposes the full API used here).
- Reuses the existing `REGISTRY`/`IMAGE_NAME` values so the pre-existing ECR/GAR repositories are reused; pushes to tag `oci-dist` so `:latest` isn't clobbered.
- Docker Hub / ECR referrers-API support varies; the client transparently falls back to the referrers tag-schema.

Related to the parallel `oci-distribution` client work.